### PR TITLE
PCCIS-32 | Upgrade runtime from Node.js 8.10 -> Node.js 12.x

### DIFF
--- a/components/actions/serverless.yml
+++ b/components/actions/serverless.yml
@@ -2,7 +2,7 @@ service: cis-serverless-backend-actions
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   region: us-east-1
   memorySize: 128 # Overwrite the default memory size. Default is 1024
   timeout: 30 # The default is 6 seconds. Note: API Gateway current maximum is 30 seconds

--- a/components/adminData/serverless.yml
+++ b/components/adminData/serverless.yml
@@ -2,7 +2,7 @@ service: serverless-backend-adminData
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   region: us-east-1
   memorySize: 128 # Overwrite the default memory size. Default is 1024
   timeout: 30 # The default is 6 seconds. Note: API Gateway current maximum is 30 seconds

--- a/components/email/serverless.yml
+++ b/components/email/serverless.yml
@@ -5,7 +5,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   #stage: ${self:custom.secrets.NODE_ENV}
   region: us-east-1
   memorySize: 128 # Overwrite the default memory size. Default is 1024

--- a/components/groups/serverless.yml
+++ b/components/groups/serverless.yml
@@ -2,7 +2,7 @@ service: cis-serverless-backend-groups
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   region: us-east-1
   memorySize: 128 # Overwrite the default memory size. Default is 1024
   timeout: 30 # The default is 6 seconds. Note: API Gateway current maximum is 30 seconds

--- a/components/levelData/serverless.yml
+++ b/components/levelData/serverless.yml
@@ -2,7 +2,7 @@ service: serverless-backend-levelData
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   region: us-east-1
   memorySize: 128 # Overwrite the default memory size. Default is 1024
   timeout: 30 # The default is 6 seconds. Note: API Gateway current maximum is 30 seconds

--- a/components/userActions/serverless.yml
+++ b/components/userActions/serverless.yml
@@ -2,7 +2,7 @@ service: serverless-backend-userActions
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   region: us-east-1
   memorySize: 128 # Overwrite the default memory size. Default is 1024
   timeout: 30 # The default is 6 seconds. Note: API Gateway current maximum is 30 seconds


### PR DESCRIPTION
Upgrades the runtime for Lambda functions from Node.js 8.10, which reached end-of-life at the end of last year, to the latest supported version, Node.js 12.x.